### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ MultiMime.type_for_extension('.json') # 'application/json'
 [![Gem Version](http://img.shields.io/gem/v/multi_mime.svg)][gem]
 [![Build Status](http://img.shields.io/travis/karlfreeman/multi_mime.svg)][travis]
 [![Code Quality](http://img.shields.io/codeclimate/github/karlfreeman/multi_mime.svg)][codeclimate]
+[![Inline docs](http://inch-pages.github.io/github/karlfreeman/multi_mime.png)](http://inch-pages.github.io/github/karlfreeman/multi_mime)
 [![Gittip](http://img.shields.io/gittip/karlfreeman.svg)][gittip]
 
 ## Supported Mime Engines


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/karlfreeman/multi_mime.png)](http://inch-pages.github.io/github/karlfreeman/multi_mime)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for MultiMime is http://inch-pages.github.io/github/karlfreeman/multi_mime/

Inch Pages is still in it's infancy, but already used by projects like the [Twitter Gem](https://github.com/sferik/twitter), [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [Libnotify](https://github.com/splattael/libnotify).

What do you think?
